### PR TITLE
Adds support for finding the ino file in the workspace

### DIFF
--- a/src/arduino/index.ts
+++ b/src/arduino/index.ts
@@ -107,8 +107,9 @@ export class ArduinoVS {
             return;
         }
 
-        if (document.isUntitled) {
+        if (document.isUntitled && document.fileName === this.config.mainFile) {
             vscode.window.showInformationMessage('Please save the file first!');
+            return;
         }
 
         if (document.isDirty) {

--- a/src/config/index.ts
+++ b/src/config/index.ts
@@ -101,12 +101,32 @@ export class ConfigUtil {
         return this._serialPort != null;
     }
 
+    get mainFile() {
+        let rootPath = vscode.workspace.rootPath;
+        let mainFile = vscode.window.activeTextEditor.document.fileName;
+
+        if (mainFile.toLowerCase().endsWith('.ino')) {
+            return mainFile;
+        }
+
+        fs.readdirSync(rootPath).forEach(file => {
+            if (file.toLowerCase().endsWith('.ino')) {
+                mainFile = rootPath + '/' + file;
+            }
+        });
+        return mainFile
+    }
+
     get basename(): string {
-        return path.basename(vscode.window.activeTextEditor.document.fileName, '.ino')
+        let mainFile = this.mainFile;
+        if (mainFile.toLowerCase().endsWith('.ino')) {
+            return path.basename(this.mainFile);
+        }
+        return path.basename(this.mainFile, '.ino');
     }
 
     get filename(): string {
-        return path.basename(vscode.window.activeTextEditor.document.fileName);
+        return path.basename(this.mainFile);
     }
 
     get hexPath(): string {
@@ -177,7 +197,7 @@ export class ConfigUtil {
         if(this._verbose)
             args.push('-verbose');
 
-        args.push(vscode.window.activeTextEditor.document.fileName);
+        args.push(this.mainFile);
 
         return this._convertSeprator ? args.map(x => x.replace(/\//g, '\\')) : args;
     }


### PR DESCRIPTION
This is a nice to have feature. It looks for the `ino` file in the root of your workspace. That way when building an arduino project the build and upload works on any `.h`, `.cpp`, or `.hpp` file. It's convenient and adds a lot of value to your extension.