### PR TITLE
append include path with  user installed lib's one.

### DIFF
--- a/src/config/index.ts
+++ b/src/config/index.ts
@@ -136,8 +136,18 @@ export class ConfigUtil {
             path.join(this._idePath, 'libraries')
         ];
 
-        if(this._libraryPath)
+        if (this._libraryPath) {
             includes.push(this._libraryPath);
+            // libs path
+            let libs = fs.readdirSync(this._libraryPath);
+            libs.forEach((libName) => {
+                if (libName.startsWith(".")) { return; }
+                let libPath = path.join(this._libraryPath,libName);
+                if (fs.statSync(libPath).isDirectory) {
+                    includes.push(libPath);            
+                }
+            });
+        }
 
         if(this._convertSeprator)
             includes = includes.map(x => x.replace(/\//g, '\\'));


### PR DESCRIPTION
This patch adds the path of the library introduced by the user to the include path of the C ++ plugin.
You can jump to the definition of the library by command click during editing.