### PR TITLE
Display size summary after building. 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 out
 node_modules
 *.vsix
+.vscode-test/

--- a/package.json
+++ b/package.json
@@ -44,17 +44,22 @@
                 "arduino.libraryPath": {
                     "type": ["string"],
                     "default": null,
-                    "description": "Specifies the serial port borad are connected (Absolute path only)."
+                    "description": "Specifies the path to your library directory. Default is used path to /Documents/Arduino/libraries (Absolute path only)."
                 },
                 "arduino.fqbn": {
                     "type": ["string"],
                     "default": "arduino:avr:uno",
-                    "description": "Specifies the borad type to use (fully qualified board name)."
+                    "description": "Specifies the board type to use (fully qualified board name). \nYou can find this value in Arduino IDE output with checked \"verbose\" option in preferences or in boards.txt file in Arduino IDE directory. \n\nFormat: {packageID}:{platformID}:{boardID}:{boardOptions}. \nPlatform ID is usually name of directory with board.txt and package ID is usually name of directory contains parent of board.txt. \nBoard ID is prefix with board name from board.txt (part before first dot). \nIf board has different versions then you must specify BoardOptions. Usualy you must provide CPU variant in format cpu=version where version is the part from board.txt after part \"cpu\". \n\nFor example for Arduino Pro Mini (Atmega328p, 8MHz) we have in board.txt entry: pro.menu.cpu.8MHzatmega168=ATmega168 (3.3V, 8 MHz). Then full qualified name is: arduino:avr:pro:cpu=8MHzatmega328"
                 },
                 "arduino.serialPort": {
                     "type": ["string"],
                     "default": null,
-                    "description": "Specifies the serial port borad are connected. (Windows: COMx, macOS: /dev/cu./dev/cu.usbmodemxxxx, Linux: /dev/ttyUSBxx)"
+                    "description": "Specifies the serial port board are connected. (Windows: COMx, macOS: /dev/cu./dev/cu.usbmodemxxxx, Linux: /dev/ttyUSBxx)"
+                },
+                "arduino.warnMode": {
+                    "type":["string"],
+                    "default": "none",
+                    "description": "Specifies warnig verbosity. Possible values: \"none\", \"default\", \"more\", \"all\"."
                 },
                 "arduino.warnPercentage": {
                     "type": ["number"],

--- a/src/config/index.ts
+++ b/src/config/index.ts
@@ -14,6 +14,7 @@ export class ConfigUtil {
     private _libraryPath: string;
     private _serialPort: string;
     private _fqbn: string;
+    private _warnMode: string;
     private _warnPercentage: number;
     private _partno: string;
     private _programmer: string;
@@ -33,6 +34,7 @@ export class ConfigUtil {
     private _updateSettings() {
         let config = vscode.workspace.getConfiguration('arduino');
         this._fqbn = config.get<string>('fqbn');
+        this._warnMode = config.get<string>('warnMode');
         this._warnPercentage = config.get<number>('warnPercentage');
         this._partno = config.get<string>('partno');
         this._programmer = config.get<string>('programmer');
@@ -167,7 +169,7 @@ export class ConfigUtil {
             '-libraries', `${this._libraryPath}`,
             `-fqbn=${this._fqbn}`,
             '-build-path', this.buildPath,
-            '-warnings=none',
+            `-warnings=${this._warnMode}`,
             `-prefs=build.warn_data_percentage=${this._warnPercentage}`,
             `-prefs=runtime.tools.avr-gcc.path=${this._idePath}/hardware/tools/avr`,
             `-prefs=runtime.tools.avrdude.path=${this._idePath}/hardware/tools/avr`,
@@ -212,6 +214,15 @@ export class ConfigUtil {
         return this._convertSeprator ? args.map(x => x.replace(/\//g, '\\')) : args;
     }
 
+    get sizeArgs(): string[] {
+        let args: string[];
+        args = ['-C',   // Used -C option, because the output is immediately in human readable format
+            `--mcu=${this._partno}`,
+            `${this.hexPath}.elf`];
+
+        return this._convertSeprator ? args.map(x => x.replace(/\//g, '\\')) : args;
+    }
+
     get builder(): string {
         let builder = path.join(this._idePath, 'arduino-builder');
 
@@ -231,6 +242,15 @@ export class ConfigUtil {
             avrdude = avrdude.replace(/\\/g, '\\') + '.exe';
 
         return avrdude;
+    }
+
+    get avrsize(): string {
+        let avrsize = path.join(this._idePath, 'hardware/tools/avr/bin/avr-size');
+
+        if (this._convertSeprator)
+            avrsize = avrsize.replace(/\\/g, '\\') + '.exe';
+
+        return avrsize;
     }
 
     get verbose(): boolean {


### PR DESCRIPTION
Hello!
I added function to display sketch size summary in output window as in Arduino IDE.
I used avr-size tool with parameter "-C". This option displays summary in format similar to output in Arduino IDE. (Arduino IDE uses flag "-A", process output with regex and next pass numeric value to string in specify language. )

I added option for specify warning verbosity in settings. I think that warnings are helpful in make better code.

I extend description FQBN parameter too, because I spend a lot of time for find correct option. I wrote this description based on code Arduino Bulder (Compiler class).

Best regards
SF