### PR TITLE
add support of board packages

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,9 +23,9 @@ Integrate the Arduino IDE for VSCode, with this extension, you can edit sketch w
 This extension contributes the following settings:
 
 * `arduino.idePath`: Specify where the Arduino IDE is (Note: Absolute path only).
-* `arduino.libraryPath`: Sprcifies the serial port borad are connected (Note: Absolute path only).
-* `arduino.fqbn`: Specifies the borad type to use (fully qualified board name).
-* `arduino.serialPort`: Specifies the serial port borad are connected. (Windows: COMx, macOS: /dev/cu./dev/cu.usbmodemxxxx, Linux: /dev/ttyUSBxx)
+* `arduino.libraryPath`: Sprcifies the serial port board are connected (Note: Absolute path only).
+* `arduino.fqbn`: Specifies the board type to use (fully qualified board name).
+* `arduino.serialPort`: Specifies the serial port board are connected. (Windows: COMx, macOS: /dev/cu./dev/cu.usbmodemxxxx, Linux: /dev/ttyUSBxx)
 * `arduino.warnPercentage`: set to `blah` to do something
 * `arduino.compileOptions`: Additional options for compile the sketch
 * `arduino.uploader`: Custom uploader for extra board types
@@ -34,8 +34,14 @@ This extension contributes the following settings:
 * `arduino.programmer`: Specify programmer type (Upload only)
 * `arduino.baudrate`: Override RS-232 baud rate (Upload only)
 * `arduino.verbose`: Use verbose output when build and upload.
+* `arduino.sketch`: Specify source file to be the sketch.
 
 Please note, every path here should be absolute path, relative path won't work.
+
+## Board Packages
+
+If you have additional board packages installed, once you specify the fqbn, this extension will read the package's configuration
+to configure the uploader and other tools used. If this doesn't work, you can still use the manual specification as described below.
 
 ## Custom uploader support
 

--- a/package.json
+++ b/package.json
@@ -1,166 +1,202 @@
 {
-    "name": "arduino-vscode",
-    "displayName": "Arduino",
-    "description": "Arduino Support for VSCode",
-    "version": "0.2.2",
-    "publisher": "steveyin",
-    "license": "LGPL-3.0",
-    "icon": "images/arduino-logo.svg",
-    "preview": true,
-    "homepage": "https://github.com/steve3d/arduino-vscode/blob/master/README.md",
-    "repository": {
-        "type": "git",
-        "url": "https://github.com/steve3d/arduino-vscode.git"
-    },
-    "engines": {
-        "vscode": "^1.5.0"
-    },
-    "extensionDependencies": [
-        "ms-vscode.cpptools"
-    ],
-    "categories": [
-        "Other"
-    ],
-    "activationEvents": [
-        "onCommand:extension.build",
-        "onCommand:extension.rebuild",
-        "onCommand:extension.clean",
-        "onCommand:extension.upload",
-        "onCommand:extension.buildAndUpload",
-        "onCommand:extension.rebuildAndUpload",
-        "onCommand:extension.initialize"
-    ],
-    "main": "./out/src/extension",
-    "contributes": {
-        "configuration": {
-            "type": "object",
-            "title": "Arduino configuration",
-            "properties": {
-                "arduino.idePath": {
-                    "type": ["string"],
-                    "default": null,
-                    "description": "Specify where the Arduino IDE is (Absolute path only)."
-                },
-                "arduino.libraryPath": {
-                    "type": ["string"],
-                    "default": null,
-                    "description": "Specifies the path to your library directory. Default is used path to /Documents/Arduino/libraries (Absolute path only)."
-                },
-                "arduino.fqbn": {
-                    "type": ["string"],
-                    "default": "arduino:avr:uno",
-                    "description": "Specifies the board type to use (fully qualified board name). \nYou can find this value in Arduino IDE output with checked \"verbose\" option in preferences or in boards.txt file in Arduino IDE directory. \n\nFormat: {packageID}:{platformID}:{boardID}:{boardOptions}. \nPlatform ID is usually name of directory with board.txt and package ID is usually name of directory contains parent of board.txt. \nBoard ID is prefix with board name from board.txt (part before first dot). \nIf board has different versions then you must specify BoardOptions. Usualy you must provide CPU variant in format cpu=version where version is the part from board.txt after part \"cpu\". \n\nFor example for Arduino Pro Mini (Atmega328p, 8MHz) we have in board.txt entry: pro.menu.cpu.8MHzatmega168=ATmega168 (3.3V, 8 MHz). Then full qualified name is: arduino:avr:pro:cpu=8MHzatmega328"
-                },
-                "arduino.serialPort": {
-                    "type": ["string"],
-                    "default": null,
-                    "description": "Specifies the serial port board are connected. (Windows: COMx, macOS: /dev/cu./dev/cu.usbmodemxxxx, Linux: /dev/ttyUSBxx)"
-                },
-                "arduino.warnMode": {
-                    "type":["string"],
-                    "default": "none",
-                    "description": "Specifies warnig verbosity. Possible values: \"none\", \"default\", \"more\", \"all\"."
-                },
-                "arduino.warnPercentage": {
-                    "type": ["number"],
-                    "default": 75,
-                    "description": ""
-                },
-                "arduino.compileOptions": {
-                    "type": ["string"],
-                    "default": "",
-                    "description": "Additional options for compile"
-                },
-                "arduino.uploader": {
-                    "type": ["string"],
-                    "default": null,
-                    "description": "Custom uploader for extra board types (Note: Set full upload options with this)"
-                },
-                "arduino.uploadOptions": {
-                    "type": ["string"],
-                    "default": "-D -q",
-                    "description": "Additional options for avrdude upload"
-                },
-                "arduino.partno": {
-                    "type": ["string"],
-                    "default": "atmega328p",
-                    "description": "Upload: Specify AVR device"
-                },
-                "arduino.programmer": {
-                    "type": ["string"],
-                    "default": "arduino",
-                    "description": "Upload: Specify programmer type"
-                },
-                "arduino.baudrate": {
-                    "type": ["number"],
-                    "default": 115200,
-                    "description": "Upload: Override RS-232 baud rate"
-                },
-                "arduino.verbose": {
-                    "type": ["boolean"],
-                    "default": false,
-                    "description": "Use verbose output in build and upload showing the build/upload flags."
-                }
-            }
+  "name": "arduino-vscode",
+  "displayName": "Arduino",
+  "description": "Arduino Support for VSCode",
+  "version": "0.2.2",
+  "publisher": "steveyin",
+  "license": "LGPL-3.0",
+  "icon": "images/arduino-logo.svg",
+  "preview": true,
+  "homepage": "https://github.com/steve3d/arduino-vscode/blob/master/README.md",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/steve3d/arduino-vscode.git"
+  },
+  "engines": {
+    "vscode": "^1.5.0"
+  },
+  "extensionDependencies": [
+    "ms-vscode.cpptools"
+  ],
+  "categories": [
+    "Other"
+  ],
+  "activationEvents": [
+    "onCommand:extension.build",
+    "onCommand:extension.rebuild",
+    "onCommand:extension.clean",
+    "onCommand:extension.upload",
+    "onCommand:extension.buildAndUpload",
+    "onCommand:extension.rebuildAndUpload",
+    "onCommand:extension.initialize"
+  ],
+  "main": "./out/src/extension",
+  "contributes": {
+    "configuration": {
+      "type": "object",
+      "title": "Arduino configuration",
+      "properties": {
+        "arduino.idePath": {
+          "type": [
+            "string"
+          ],
+          "default": null,
+          "description": "Specify where the Arduino IDE is (Absolute path only)."
         },
-        "commands": [
-            {
-                "command": "extension.build",
-                "title": "Arduino: Build",
-                "icon": "./images/compile.svg"
-            },
-            {
-                "command": "extension.rebuild",
-                "title": "Arduino: Rebuild"
-            },
-            {
-                "command": "extension.clean",
-                "title": "Arduino: Clean"
-            },
-            {
-                "command": "extension.upload",
-                "title": "Arduino: Upload",
-                "icon": "./images/upload.svg"
-            },
-            {
-                "command": "extension.buildAndUpload",
-                "title": "Arduino: Build & Upload"
-            },
-            {
-                "command": "extension.rebuildAndUpload",
-                "title": "Arduino: Rebuild & Upload"
-            },
-            {
-                "command": "extension.initialize",
-                "title": "Arduino: Initialize C++ Intellisense"
-            }
-        ],
-        "menus": {
-            "editor/title": [
-                {
-                    "when": "resourceLangId == cpp",
-                    "command": "extension.build",
-                    "group": "navigation"
-                },
-                {
-                    "when": "resourceLangId == cpp",
-                    "command": "extension.upload",
-                    "group": "navigation"
-                }
-            ]
+        "arduino.libraryPath": {
+          "type": [
+            "string"
+          ],
+          "default": null,
+          "description": "Specifies the path to your library directory. Default is used path to /Documents/Arduino/libraries (Absolute path only)."
+        },
+        "arduino.fqbn": {
+          "type": [
+            "string"
+          ],
+          "default": "arduino:avr:uno",
+          "description": "Specifies the board type to use (fully qualified board name). \nYou can find this value in Arduino IDE output with checked \"verbose\" option in preferences or in boards.txt file in Arduino IDE directory. \n\nFormat: {packageID}:{platformID}:{boardID}:{boardOptions}. \nPlatform ID is usually name of directory with board.txt and package ID is usually name of directory contains parent of board.txt. \nBoard ID is prefix with board name from board.txt (part before first dot). \nIf board has different versions then you must specify BoardOptions. Usualy you must provide CPU variant in format cpu=version where version is the part from board.txt after part \"cpu\". \n\nFor example for Arduino Pro Mini (Atmega328p, 8MHz) we have in board.txt entry: pro.menu.cpu.8MHzatmega168=ATmega168 (3.3V, 8 MHz). Then full qualified name is: arduino:avr:pro:cpu=8MHzatmega328"
+        },
+        "arduino.serialPort": {
+          "type": [
+            "string"
+          ],
+          "default": null,
+          "description": "Specifies the serial port board are connected. (Windows: COMx, macOS: /dev/cu./dev/cu.usbmodemxxxx, Linux: /dev/ttyUSBxx)"
+        },
+        "arduino.warnMode": {
+          "type": [
+            "string"
+          ],
+          "default": "none",
+          "description": "Specifies warnig verbosity. Possible values: \"none\", \"default\", \"more\", \"all\"."
+        },
+        "arduino.warnPercentage": {
+          "type": [
+            "number"
+          ],
+          "default": 75,
+          "description": ""
+        },
+        "arduino.compileOptions": {
+          "type": [
+            "string"
+          ],
+          "default": "",
+          "description": "Additional options for compile"
+        },
+        "arduino.uploader": {
+          "type": [
+            "string"
+          ],
+          "default": null,
+          "description": "Custom uploader for extra board types (Note: Set full upload options with this)"
+        },
+        "arduino.uploadOptions": {
+          "type": [
+            "string"
+          ],
+          "default": "-D -q",
+          "description": "Additional options for avrdude upload"
+        },
+        "arduino.partno": {
+          "type": [
+            "string"
+          ],
+          "default": "atmega328p",
+          "description": "Upload: Specify AVR device"
+        },
+        "arduino.programmer": {
+          "type": [
+            "string"
+          ],
+          "default": "arduino",
+          "description": "Upload: Specify programmer type"
+        },
+        "arduino.baudrate": {
+          "type": [
+            "number"
+          ],
+          "default": 115200,
+          "description": "Upload: Override RS-232 baud rate"
+        },
+        "arduino.verbose": {
+          "type": [
+            "boolean"
+          ],
+          "default": false,
+          "description": "Use verbose output in build and upload showing the build/upload flags."
+        },
+        "arduino.sketch": {
+          "type": [
+            "string"
+          ],
+          "default": "<current file>",
+          "description": "Specify which source file is your sketch. If not specified, then the currently opened file is used."
         }
+      }
     },
-    "scripts": {
-        "vscode:prepublish": "tsc -p ./",
-        "compile": "tsc -watch -p ./",
-        "postinstall": "node ./node_modules/vscode/bin/install",
-        "test": "node ./node_modules/vscode/bin/test"
-    },
-    "devDependencies": {
-        "typescript": "^2.0.3",
-        "vscode": "^1.0.0",
-        "mocha": "^2.3.3",
-        "@types/node": "^6.0.40",
-        "@types/mocha": "^2.2.32"
+    "commands": [
+      {
+        "command": "extension.build",
+        "title": "Arduino: Build",
+        "icon": "./images/compile.svg"
+      },
+      {
+        "command": "extension.rebuild",
+        "title": "Arduino: Rebuild"
+      },
+      {
+        "command": "extension.clean",
+        "title": "Arduino: Clean"
+      },
+      {
+        "command": "extension.upload",
+        "title": "Arduino: Upload",
+        "icon": "./images/upload.svg"
+      },
+      {
+        "command": "extension.buildAndUpload",
+        "title": "Arduino: Build & Upload"
+      },
+      {
+        "command": "extension.rebuildAndUpload",
+        "title": "Arduino: Rebuild & Upload"
+      },
+      {
+        "command": "extension.initialize",
+        "title": "Arduino: Initialize C++ Intellisense"
+      }
+    ],
+    "menus": {
+      "editor/title": [
+        {
+          "when": "resourceLangId == cpp",
+          "command": "extension.build",
+          "group": "navigation"
+        },
+        {
+          "when": "resourceLangId == cpp",
+          "command": "extension.upload",
+          "group": "navigation"
+        }
+      ]
     }
+  },
+  "scripts": {
+    "vscode:prepublish": "tsc -p ./",
+    "compile": "tsc -watch -p ./",
+    "postinstall": "node ./node_modules/vscode/bin/install",
+    "test": "node ./node_modules/vscode/bin/test"
+  },
+  "devDependencies": {
+    "typescript": "^2.0.3",
+    "vscode": "^1.0.0",
+    "mocha": "^2.3.3",
+    "@types/node": "^6.0.40",
+    "@types/mocha": "^2.2.32"
+  },
+  "dependencies": {
+    "splitargs": "0.0.7"
+  }
 }

--- a/package.json
+++ b/package.json
@@ -131,7 +131,7 @@
           "type": [
             "string"
           ],
-          "default": "<current file>",
+          "default": null,
           "description": "Specify which source file is your sketch. If not specified, then the currently opened file is used."
         }
       }

--- a/src/config/index.ts
+++ b/src/config/index.ts
@@ -1,17 +1,19 @@
+
 'use strict';
 
 import * as vscode from 'vscode';
 import * as os from 'os';
 import * as path from 'path';
 import * as fs from 'fs';
-import * as process from 'process';
-
+import * as child_process from 'child_process';
+let splitargs = require('splitargs');
 
 export class ConfigUtil {
-
-    private _convertSeprator = false;
+    private _builder: string;
     private _idePath: string;
+    private _sketchName: string;
     private _libraryPath: string;
+    private _packagePath: string;
     private _serialPort: string;
     private _fqbn: string;
     private _warnMode: string;
@@ -23,78 +25,191 @@ export class ConfigUtil {
     private _uploader: string = null;
     private _uploadOptions: string[];
     private _verbose: boolean;
+    private _vconfig: vscode.WorkspaceConfiguration;
+    private _osSuffix: string = null;
+    private _exeSuffix: string = '';
+    private _config: {};
+    private _output: vscode.OutputChannel;
 
-    constructor() {
-        if(os.type() == 'Windows_NT')
-            this._convertSeprator = true;
+    constructor(output: vscode.OutputChannel) {
         this._updateSettings();
+        this._output = output;
         vscode.workspace.onDidChangeConfiguration((e) => this._updateSettings());
     }
 
-    private _updateSettings() {
-        let config = vscode.workspace.getConfiguration('arduino');
-        this._fqbn = config.get<string>('fqbn');
+    private _updateLegacy() {
+        let config = this._vconfig;
         this._warnMode = config.get<string>('warnMode');
         this._warnPercentage = config.get<number>('warnPercentage');
         this._partno = config.get<string>('partno');
         this._programmer = config.get<string>('programmer');
         this._baudrate = config.get<number>('baudrate');
+        this._uploader = config.get<string>('uploader');
         this._serialPort = config.get<string>('serialPort');
         this._verbose = config.get<boolean>('verbose');
-
-        this._compileOptions = config.get<string>('compileOptions', '').split(' ').filter(x => x != '');
-
-        this._uploader = config.get<string>('uploader');
-        this._uploadOptions = config.get<string>('uploadOptions', '').split(' ').filter(x => x != '');
-
-        this._updateIdePath(config);
-        this._updateLibraryPath(config);
+        this._sketchName = config.get<string>('sketch')
     }
 
-    private _updateIdePath(config: vscode.WorkspaceConfiguration) {
-        this._idePath = config.get<string>('idePath');
+    private _updateSettings() {
+        this._vconfig = vscode.workspace.getConfiguration('arduino');
+        this._config = {};
+        this._fqbn = this._vconfig.has('fqbn') ? this._vconfig.get<string>('fqbn') : 'arduino:avr:uno';
+        this._updateLegacy();
+        this._config['upload.verbose'] = this._vconfig.get<boolean>('verbose') ? '-verbose' : '';
+        this._config['serial.port'] = this._vconfig.get<string>('serialPort');
+        this._updateOSDefaults();
+        this._updateIdePath();
+        this._updateLibraryPath();
+        this._updatePackagePath();
+        this._updateFromBuilder();
+        this._config['build.path'] = this.buildPath;
+        this._updateFromPlatform();
+        this._validateSettings();
+    }
 
+    private _updateFromPlatform() {
+        let uploader = this.rval('upload.tool');
+        if (!uploader) return;
+
+        let cl = this._unpackPattern('tools.'+ uploader + '.upload.pattern')
+
+        this._config['arduino.platform.uploader'] = cl[0];
+
+        cl = this._unpackPattern('recipe.size.pattern')
+        this._config['arduino.platform.sizer'] = cl[0];
+
+    }
+
+    private _updateOSDefaults() {
+        this._exeSuffix = ''
         switch(os.type()) {
             case 'Windows_NT':
-                if(this._idePath == null)
-                    this._idePath = 'C:\\Program Files (x86)\\Arduino';
-
-                if(!fs.existsSync(path.join(this._idePath, 'arduino-builder.exe')))
-                    this._idePath = null
+                this._idePath = 'C:\\Program Files (x86)\\Arduino';
+                this._packagePath = process.env.APPDATA
+                this._exeSuffix = '.exe'
+                this._osSuffix = '.windows'
                 break;
             case 'Linux':
-                if(!fs.existsSync(path.join(this._idePath, 'arduino-builder')))
-                    this._idePath = null
+                this._osSuffix = '.linux'
                 break;
             case 'Darwin':
-                if(this._idePath == null)
-                    this._idePath = '/Applications/Arduino.app'
-
-                if(fs.existsSync(path.join(this._idePath, 'Contents/Java/arduino-builder')))
-                    this._idePath = path.join(this._idePath, 'Contents/Java');
-                else
-                    this._idePath = null;
-
+                this._idePath = '/Applications/Arduino.app/Contents/Java'
+                this._packagePath = path.join(os.homedir(),'Library/Arduino15');
                 break;
-            default:
-                this._idePath = null;
+        }
+        this._builder = 'arduino-builder' + this._exeSuffix;
+        this._libraryPath = path.join(os.homedir(), 'Documents/Arduino/libraries');
+    }
+
+    private _updateFromBuilder() {
+        let builder = this.builder;
+        if (!fs.existsSync(builder))
+            builder = this._builder;
+        if (!fs.existsSync(builder))
+            return;
+        let args = this.minBuildArgs;
+        args.push('-dump-prefs');
+
+        let spawn = child_process.spawnSync(builder, args);
+        if (spawn.status != 0) {
+            this._output.append(spawn.stderr.toString());
+            return;
         }
 
+        let prefs = spawn.stdout.toString().split('\n');
+        for (var i = 0; i < prefs.length; ++i) {
+            var kv = prefs[i].trim().split('=');
+            if (kv.length == 2) {
+                this._config[kv[0]] = kv[1];
+            }
+        }
+    }
+
+    private _evaluate(key:string, parent?:string) {
+        if (!key) return '';
+        // this needs to be a last second thing
+        this._config['build.project_name']  = this.filename;
+        if (!this._config.hasOwnProperty(key)) return '';
+        let parts = key.split('.');
+        //by inspection, there've not been any parentage more that two levels
+        if (!parent && parts.length > 1) {
+            parent = parts.slice(0,parts.length-1).join('.');
+        }
+        let gparent = null;
+        if (parts.length > 2) {
+            gparent = parts.slice(0,parts.length-2).join('.');
+        }
+        let v = this.rval(key);
+        let s = v.indexOf('{');
+        while (s >= 0) {
+            let e = v.indexOf('}', s + 1);
+            if (e == -1) break;
+            let sk = v.substring(s + 1, e);
+            let at = e + 1;
+            if (this._config.hasOwnProperty(sk)) {
+                // some things can be overridden as params
+                let skp = sk.split('.');
+                let vp = null;
+                if (skp.length==2) {
+                    if (skp[0] == parts[parts.length-2]) {
+                        let pskp = parent + '.params.' + skp[1];
+                        if (this._config.hasOwnProperty(pskp)) {
+                            vp = this.oval(pskp);
+                        }
+                    }
+                }
+                if (!vp)
+                    vp = this.oval(sk);
+                v = v.substring(0, s) + vp + v.substring(e + 1);
+                at = s;
+            } else if (this._config.hasOwnProperty(parent + "." + sk)) {
+                v = v.substring(0, s) + this.oval(parent + "." + sk) + v.substring(e + 1);
+                at = s;
+            } else if (this._config.hasOwnProperty(gparent + "." + sk)) {
+                v = v.substring(0, s) + this.oval(gparent + "." + sk) + v.substring(e + 1);
+                at = s;
+            }
+            s = v.indexOf('{', at);
+        }
+        return v;
+    }
+
+    private _validateSettings() {
+        // builder must be accessible
+        if (!fs.existsSync(this.builder))
+            this._idePath = null;
         // custom uploader must also exists
-        if(this._uploader && !fs.existsSync(this._uploader))
+        if (this.uploader && !(fs.existsSync(this.uploader)))
             this._uploader = null;
+
     }
 
-    private _updateLibraryPath(config: vscode.WorkspaceConfiguration) {
-        this._libraryPath = config.get<string>('libraryPath');
-
-        if(this._libraryPath == null) {
-            this._libraryPath = path.join(os.homedir(), 'Documents/Arduino/libraries');
-            if(!fs.existsSync(this._libraryPath))
-                this._libraryPath = os.homedir();
+    private _updateIdePath() {
+        if (this._vconfig.has('idePath')) {
+            this._idePath = this._vconfig.get<string>('idePath');
         }
+        if (os.type() == 'Darwin')
+            if (!this._idePath.endsWith('Contents/Java'))
+                this._idePath = path.join(this._idePath, 'Contents/Java');
+        if (!fs.existsSync(this._idePath))
+            this._idePath = null;
     }
 
+    private _updateLibraryPath() {
+        if (this._vconfig.has('libraryPath'))
+            this._libraryPath = this._vconfig.get<string>('libraryPath');
+    }
+
+    private _updatePackagePath() {
+        if (this._vconfig.has('packagePath'))
+            this._packagePath = this._vconfig.get<string>('packagePath');
+        if (!this._packagePath.endsWith('packages'))
+            this._packagePath = path.join(this._packagePath, 'packages');
+    }
+
+    get hasValidFilename(): boolean {
+        return this.filename.endsWith(".ino") || this.filename.endsWith(".pde");
+    }
     get hasIdePath(): boolean {
         return this._idePath != null;
     }
@@ -104,11 +219,16 @@ export class ConfigUtil {
     }
 
     get basename(): string {
-        return path.basename(vscode.window.activeTextEditor.document.fileName, '.ino')
+        return path.basename(this.filename,'.ino');
     }
 
     get filename(): string {
+        if (this._sketchName) return this._sketchName
         return path.basename(vscode.window.activeTextEditor.document.fileName);
+    }
+
+    get sketchPath(): string {
+        return path.join(vscode.workspace.rootPath, this.filename);
     }
 
     get hexPath(): string {
@@ -116,20 +236,29 @@ export class ConfigUtil {
     }
 
     get buildPath(): string {
-        let document = vscode.window.activeTextEditor.document;
+        if (!this._config.hasOwnProperty('vscode.build.path')) {
 
-        let buildPath = path.join(vscode.workspace.rootPath, `.build`);
+            let buildPath = path.join(vscode.workspace.rootPath, `.build`);
 
-        if (!fs.existsSync(buildPath))
-            fs.mkdirSync(buildPath);
+            if (!fs.existsSync(buildPath))
+                fs.mkdirSync(buildPath);
 
-        buildPath = path.join(buildPath, this.basename);
-        if (!fs.existsSync(buildPath))
-            fs.mkdirSync(buildPath);
+            buildPath = path.join(buildPath, this.filename);
+            if (!fs.existsSync(buildPath))
+                fs.mkdirSync(buildPath);
 
-        return buildPath;
+            this._config['build.path'] = buildPath;
+            this._config['vscode.build.path'] = buildPath;
+        }
+        return this._config['vscode.build.path'];
     }
-
+    private _updatePathsForOS(path:any): any {
+        if (Array.isArray(path))
+            return path.map(x=>this._updatePathsForOS(x))
+        if (this._osSuffix === ".windows")
+            return path.replace(/\//g, '\\');
+        return path
+    }
     get cppConfig(): any {
         let includes = [
             path.join(this._idePath, 'hardware/arduino/avr/cores/arduino'),
@@ -147,8 +276,7 @@ export class ConfigUtil {
                 .forEach(item => includes.push(item));
         }
 
-        if(this._convertSeprator)
-            includes = includes.map(x => x.replace(/\//g, '\\'));
+        includes = this._updatePathsForOS(includes);
 
         return {
             configurations: [
@@ -164,33 +292,50 @@ export class ConfigUtil {
         };
     }
 
-    get buildArgs(): string[] {
+    get minBuildArgs(): string[] {
         let args = [
-            '-compile',
             '-logger', this._verbose ? 'human' : 'machine',
             '-hardware', `${this._idePath}/hardware`,
+            '-hardware', `${this._packagePath}`,
             '-tools', `${this._idePath}/tools-builder`,
             '-tools', `${this._idePath}/hardware/tools/avr`,
+            '-tools', `${this._packagePath}`,
             '-built-in-libraries', `${this._idePath}/libraries`,
             '-libraries', `${this._libraryPath}`,
             `-fqbn=${this._fqbn}`,
+        ];
+        return args;
+    }
+    get buildArgs(): string[] {
+        let args = this.minBuildArgs.concat(
+            [
+            '-compile',
             '-build-path', this.buildPath,
             `-warnings=${this._warnMode}`,
-            `-prefs=build.warn_data_percentage=${this._warnPercentage}`,
-            `-prefs=runtime.tools.avr-gcc.path=${this._idePath}/hardware/tools/avr`,
-            `-prefs=runtime.tools.avrdude.path=${this._idePath}/hardware/tools/avr`,
-            `-prefs=runtime.tools.arduinoOTA.path=${this._idePath}/hardware/tools/avr`,
-        ].concat(this._compileOptions);
+            `-prefs=build.warn_data_percentage=${this._warnPercentage}`
+        ]);
+        if (this._compileOptions)
+            args.concat(this._compileOptions);
 
         if(this._verbose)
             args.push('-verbose');
 
-        args.push(vscode.window.activeTextEditor.document.fileName);
+        args.push(this.sketchPath);
 
-        return this._convertSeprator ? args.map(x => x.replace(/\//g, '\\')) : args;
+        return this._updatePathsForOS(args);
+    }
+    private _unquote(a: string) {
+        if (a.startsWith('"') && a.endsWith('"'))
+            return a.substring(1, a.length - 1);
+        return a;
+    }
+    private _unquoteArgs(args: string[]) {
+        return args.map(a=>{
+            return this._unquote(a);
+        })
     }
 
-    get uploadArgs(): string[] {
+    private _legacyUploadArgs() {
         let args: string[];
         if(this._uploader) {
             args = this._uploadOptions
@@ -204,7 +349,6 @@ export class ConfigUtil {
                             case '$SERIALPORT':
                                 return this._serialPort;
                         }
-
                         return match;
                     } ));
         } else {
@@ -216,50 +360,84 @@ export class ConfigUtil {
             ].concat(this._uploadOptions,
                 `-Uflash:w:${this.hexPath}.hex:i`);
         }
-
-        return this._convertSeprator ? args.map(x => x.replace(/\//g, '\\')) : args;
+        return this._updatePathsForOS(args);
     }
-
-    get sizeArgs(): string[] {
-        let args: string[];
-        args = ['-C',   // Used -C option, because the output is immediately in human readable format
-            `--mcu=${this._partno}`,
-            `${this.hexPath}.elf`];
-
-        return this._convertSeprator ? args.map(x => x.replace(/\//g, '\\')) : args;
-    }
-
     get builder(): string {
-        let builder = path.join(this._idePath, 'arduino-builder');
-
-        if(this._convertSeprator)
-            builder = builder.replace(/\//g, '\\') + '.exe';
-
-        return builder;
+        return path.join(this._idePath, this._builder);
     }
 
-    get avrdude(): string {
-        if(this._uploader)
-            return this._uploader;
-
-        let avrdude = path.join(this._idePath, 'hardware/tools/avr/bin/avrdude');
-
-        if(this._convertSeprator)
-            avrdude = avrdude.replace(/\\/g, '\\') + '.exe';
-
-        return avrdude;
+    private hasval(key:string) : boolean {
+        return this._config.hasOwnProperty(key);
     }
 
-    get avrsize(): string {
-        let avrsize = path.join(this._idePath, 'hardware/tools/avr/bin/avr-size');
+    private oval(key:string) {
+        // this would be the canonical response
+        if (this._osSuffix && this.hasval(key + this._osSuffix))
+            return this.rval(key + this._osSuffix);
+        else
+        {
+        // this is the heuristic response
+            let suffix = ''
+            if (key.endsWith('.cmd') || key.indexOf('.cmd.') > -1)
+                return this.rval(key) + this._exeSuffix;
+            else
+            return this.rval(key);
+        }
+    }
 
-        if (this._convertSeprator)
-            avrsize = avrsize.replace(/\\/g, '\\') + '.exe';
+    // raw value from config
+    rval(key:string): any {
+        if (this.hasval(key))
+            return this._config[key];
+        else
+            return null;
+    }
 
-        return avrsize;
+    // expanded value from config
+    val(key:string): string {
+        if (this._config.hasOwnProperty(key))
+            return this._evaluate(key);
+        else
+            return null;
+    }
+
+
+    private _unpackPattern(key): string[] {
+        let pattern = this.val(key);
+        let parts = splitargs(pattern)
+        return parts
+    }
+
+    // backwards compat
+    get avrdude(): string { return this.uploader; }
+    get uploader(): string {
+    	return this._uploader ? this._uploader : this._config['arduino.platform.uploader'];
+    }
+
+    // backwards compat
+    get uploadArgs(): string[] { return this.uploaderArgs; }
+    get uploaderArgs(): string[] {
+        if (this._uploader)
+            return this._legacyUploadArgs();
+
+        let uploader = this.rval('upload.tool');
+        let cl = this._unpackPattern('tools.'+ uploader + '.upload.pattern')
+        return cl.slice(1);
+    }
+
+    // backwards compat
+    get avrsize(): string { return this.sizer; }
+    get sizer(): string {
+    	return this._config['arduino.platform.sizer'];
+    }
+    // backwards compat
+    get sizeArgs(): string[] { return this.sizerArgs; }
+    get sizerArgs(): string[] {
+        let cl = this._unpackPattern('recipe.size.pattern')
+        return cl.slice(1);
     }
 
     get verbose(): boolean {
-        return this._verbose;
+    	return this._verbose;
     }
 }


### PR DESCRIPTION
I've added support of board packages which require removing some of the hardcoded parameters to the underlying tools. I've tested with the HUZZAH board using the esp8266 board package. This change means that you don't have to figure out what the uploader command is or the oversize command or any of that other stuff as it reads it all from the board's package.

I also added a new configuration option to specify which file is the sketch and an error message if the currently selected file is not a sketch file.

I was originally going to do a bit more with cleanup before submitting a PR, but the last set of changes messed up my updates enough that I figured that I'd just see if you wanted to add. 

I think the that everything that was in place should still work.